### PR TITLE
Add pack voltage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # soc-calc
 this is the code for the leoch batteries  LDC6-400-L16 (6V400Ah)
+
+This version adds an option to enter the total pack voltage for a 24-cell pack.

--- a/index.html
+++ b/index.html
@@ -40,6 +40,10 @@
       Measured Voltage (V):
       <input id="volt" type="number" step="0.001" value="2.02" disabled>
     </label>
+    <label>
+      <input id="pack" type="checkbox" disabled>
+      Total pack voltage (24 cells)
+    </label>
     <button id="calc" disabled>Calculate &amp; Plot</button>
     <p>Estimated SoC: <strong><span id="out">--</span>%</strong></p>
   </div>
@@ -98,10 +102,14 @@
       ctx.lineWidth = 2; ctx.strokeStyle = 'white'; ctx.stroke();
     }
 
+    const packChk = document.getElementById('pack');
+
     img.onload = () => {
       document.getElementById('volt').disabled = false;
+      packChk.disabled = false;
       document.getElementById('calc').disabled = false;
-      const v0 = parseFloat(document.getElementById('volt').value);
+      const raw = parseFloat(document.getElementById('volt').value);
+      const v0 = packChk.checked ? raw / 24 : raw;
       const s0 = invertSoC(v0);
       document.getElementById('out').textContent = s0.toFixed(2);
       plotPoint(s0, v0);
@@ -109,7 +117,8 @@
     if (img.complete) img.onload();
 
     document.getElementById('calc').onclick = () => {
-      const v = parseFloat(document.getElementById('volt').value);
+      const raw = parseFloat(document.getElementById('volt').value);
+      const v = packChk.checked ? raw / 24 : raw;
       const s = invertSoC(v);
       document.getElementById('out').textContent = s.toFixed(2);
       plotPoint(s, v);


### PR DESCRIPTION
## Summary
- allow entering total pack voltage
- convert pack voltage to per-cell value before SoC lookup
- document the new option in README
- tag v1.1 release

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686a9fd3519c8322a4a87f7fdebbcdad